### PR TITLE
Fix restrict keyword for qemu 0.10 build

### DIFF
--- a/qemu-0.10.0/slirp/libslirp.h
+++ b/qemu-0.10.0/slirp/libslirp.h
@@ -5,7 +5,8 @@
 extern "C" {
 #endif
 
-void slirp_init(int restrict, char *special_ip);
+/* rename parameter from 'restrict' to avoid C99 keyword clash */
+void slirp_init(int restrict_flag, char *special_ip);
 
 void slirp_select_fill(int *pnfds,
                        fd_set *readfds, fd_set *writefds, fd_set *xfds);

--- a/qemu-0.10.0/slirp/slirp.c
+++ b/qemu-0.10.0/slirp/slirp.c
@@ -171,7 +171,8 @@ static void slirp_cleanup(void)
 static void slirp_state_save(QEMUFile *f, void *opaque);
 static int slirp_state_load(QEMUFile *f, void *opaque, int version_id);
 
-void slirp_init(int restrict, char *special_ip)
+/* avoid using the C99 reserved keyword 'restrict' as a parameter name */
+void slirp_init(int restrict_flag, char *special_ip)
 {
     //    debug_init("/tmp/slirp.log", DEBUG_DEFAULT);
 
@@ -184,7 +185,7 @@ void slirp_init(int restrict, char *special_ip)
 #endif
 
     link_up = 1;
-    slirp_restrict = restrict;
+    slirp_restrict = restrict_flag;
 
     if_init();
     ip_init();


### PR DESCRIPTION
## Summary
- fix slirp initialization function parameter so it doesn't use the C99 `restrict` keyword
- confirm SDL support in configure output and compile successfully

## Testing
- `./configure --target-list=i386-softmmu > /tmp/config.log`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6850504233c8832cb9fc16bb518168c3