### PR TITLE
Enable building QEMU 0.9.1 with modern toolchains

### DIFF
--- a/qemu-0.9.1/Makefile
+++ b/qemu-0.9.1/Makefile
@@ -2,6 +2,10 @@
 
 include config-host.mak
 
+# Allow builds with modern GCC which defaults to -fno-common.
+# Older QEMU versions expect -fcommon for globals defined in headers.
+CFLAGS += -fcommon
+
 .PHONY: all clean distclean dvi info install install-doc tar tarbin \
 	speed test html dvi info
 

--- a/qemu-0.9.1/block-raw-posix.c
+++ b/qemu-0.9.1/block-raw-posix.c
@@ -48,6 +48,7 @@
 #include <sys/dkio.h>
 #endif
 #ifdef __linux__
+#include <signal.h>
 #include <sys/ioctl.h>
 #include <linux/cdrom.h>
 #include <linux/fd.h>


### PR DESCRIPTION
## Summary
- add `-fcommon` to `CFLAGS` to avoid multiple symbol errors with GCC 13
- include `<signal.h>` on Linux for raw POSIX block driver

## Testing
- `./configure --disable-gcc-check --disable-gfx-check`
- `make qemu-img`


------
https://chatgpt.com/codex/tasks/task_e_685051508280832cb3a5d602cd7a093d