### PR TITLE
Add Dockerfile for building QEMU 0.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM i386/debian:stable-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libsdl1.2-dev \
+    libasound2-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY qemu-0.9.1 /build/qemu-0.9.1
+
+WORKDIR /build/qemu-0.9.1
+
+RUN ./configure --prefix=/usr/local --disable-gcc-check --target-list=i386-softmmu --enable-sdl \
+    && make -j$(nproc) \
+    && make install
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # qemu-0.9-0.10
+
+This repository contains QEMU versions 0.9.1 and 0.10.0.
+
+A `Dockerfile` is included for building QEMU 0.9.1 with SDL support in a 32‑bit
+Debian environment. Use the following commands:
+
+```bash
+docker build -t qemu-0.9.1 .
+```
+
+To run an interactive shell inside the container:
+
+```bash
+docker run -it --rm qemu-0.9.1
+```
+
+The build outputs are installed under `/usr/local` inside the container.


### PR DESCRIPTION
## Summary
- add a Dockerfile with a 32-bit Debian base
- install SDL and build QEMU 0.9.1 inside the container
- document Docker build instructions in README

## Testing
- `pytest -q` *(no tests found)*
- `flake8` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850542d8b74832c8a920241105dbab5