### PR TITLE
Add Docker out-of-tree build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM i386/debian:stable-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libsdl1.2-dev \
+    libasound2-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY qemu-0.9.1 /src/qemu-0.9.1
+
+WORKDIR /build
+
+RUN mkdir qemu-build && cd qemu-build && \
+    /src/qemu-0.9.1/configure --prefix=/usr/local --disable-gcc-check --target-list=i386-softmmu --enable-sdl && \
+    make -j$(nproc) && \
+    make install
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # qemu-0.9-0.10
+
+This repository contains QEMU versions 0.9.1 and 0.10.0.
+
+A `Dockerfile` is included for building QEMU 0.9.1 with SDL support in a 32‑bit
+Debian environment. Use the following commands:
+
+```bash
+docker build -t qemu-0.9.1 .
+```
+
+The build uses an out-of-tree directory to keep the source clean. To run an
+interactive shell and store the build results on the host, mount a volume:
+
+```bash
+docker run -it --rm -v "$PWD/output:/usr/local" qemu-0.9.1
+```
+
+The compiled binaries will appear in the `output` directory on the host.


### PR DESCRIPTION
## Summary
- adjust Dockerfile to build QEMU 0.9.1 in a separate directory
- explain how to mount an output directory from the host in README

## Testing
- `pytest -q`
- `flake8` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850542d8b74832c8a920241105dbab5