### PR TITLE
Refine S3 ViRGE option

### DIFF
--- a/qemu-0.10.0/Makefile.target
+++ b/qemu-0.10.0/Makefile.target
@@ -582,7 +582,7 @@ ifeq ($(TARGET_BASE_ARCH), i386)
 OBJS+= ide.o pckbd.o ps2.o vga.o $(SOUND_HW) dma.o
 OBJS+= fdc.o mc146818rtc.o serial.o i8259.o i8254.o pcspk.o pc.o
 OBJS+= cirrus_vga.o apic.o parallel.o acpi.o piix_pci.o
-OBJS+= usb-uhci.o vmmouse.o vmport.o vmware_vga.o hpet.o
+OBJS+= usb-uhci.o vmmouse.o vmport.o vmware_vga.o s3_virge_vga.o hpet.o
 OBJS += device-hotplug.o pci-hotplug.o
 CPPFLAGS += -DHAS_AUDIO -DHAS_AUDIO_CHOICE
 endif
@@ -617,10 +617,10 @@ OBJS+= mips_r4k.o mips_jazz.o mips_malta.o mips_mipssim.o
 OBJS+= mips_timer.o mips_int.o dma.o vga.o serial.o i8254.o i8259.o rc4030.o
 OBJS+= g364fb.o jazz_led.o
 OBJS+= ide.o gt64xxx.o pckbd.o ps2.o fdc.o mc146818rtc.o usb-uhci.o acpi.o ds1225y.o
-OBJS+= piix_pci.o parallel.o cirrus_vga.o pcspk.o $(SOUND_HW)
+OBJS+= piix_pci.o parallel.o cirrus_vga.o s3_virge_vga.o pcspk.o $(SOUND_HW)
 OBJS+= mipsnet.o
 OBJS+= pflash_cfi01.o
-OBJS+= vmware_vga.o
+OBJS+= vmware_vga.o s3_virge_vga.o
 CPPFLAGS += -DHAS_AUDIO -DHAS_AUDIO_CHOICE
 endif
 ifeq ($(TARGET_BASE_ARCH), cris)
@@ -641,7 +641,7 @@ ifeq ($(TARGET_BASE_ARCH), sparc)
 ifeq ($(TARGET_ARCH), sparc64)
 OBJS+= sun4u.o ide.o pckbd.o ps2.o vga.o apb_pci.o
 OBJS+= fdc.o mc146818rtc.o serial.o m48t59.o
-OBJS+= cirrus_vga.o parallel.o ptimer.o
+OBJS+= cirrus_vga.o s3_virge_vga.o parallel.o ptimer.o
 else
 OBJS+= sun4m.o tcx.o pcnet.o iommu.o m48t59.o slavio_intctl.o
 OBJS+= slavio_timer.o escc.o slavio_misc.o fdc.o sparc32_dma.o

--- a/qemu-0.10.0/hw/mips_malta.c
+++ b/qemu-0.10.0/hw/mips_malta.c
@@ -941,7 +941,10 @@ void mips_malta_init (ram_addr_t ram_size, int vga_ram_size,
     network_init(pci_bus);
 
     /* Optional PCI video card */
-    if (cirrus_vga_enabled) {
+    if (s3_vga_enabled) {
+        pci_s3virge_vga_init(pci_bus, phys_ram_base + ram_size,
+                             ram_size, vga_ram_size);
+    } else if (cirrus_vga_enabled) {
         pci_cirrus_vga_init(pci_bus, phys_ram_base + ram_size,
                             ram_size, vga_ram_size);
     } else if (vmsvga_enabled) {

--- a/qemu-0.10.0/hw/pc.c
+++ b/qemu-0.10.0/hw/pc.c
@@ -44,6 +44,7 @@
 #define BIOS_FILENAME "bios.bin"
 #define VGABIOS_FILENAME "vgabios.bin"
 #define VGABIOS_CIRRUS_FILENAME "vgabios-cirrus.bin"
+#define VGABIOS_S3VIRGE_FILENAME "vgabios-s3virge.bin"
 
 #define PC_MAX_BIOS_SIZE (4 * 1024 * 1024)
 
@@ -857,10 +858,12 @@ static void pc_init1(ram_addr_t ram_size, int vga_ram_size,
         exit(1);
     }
 
-    if (cirrus_vga_enabled || std_vga_enabled || vmsvga_enabled) {
+    if (cirrus_vga_enabled || std_vga_enabled || vmsvga_enabled || s3_vga_enabled) {
         /* VGA BIOS load */
         if (cirrus_vga_enabled) {
             snprintf(buf, sizeof(buf), "%s/%s", bios_dir, VGABIOS_CIRRUS_FILENAME);
+        } else if (s3_vga_enabled) {
+            snprintf(buf, sizeof(buf), "%s/%s", bios_dir, VGABIOS_S3VIRGE_FILENAME);
         } else {
             snprintf(buf, sizeof(buf), "%s/%s", bios_dir, VGABIOS_FILENAME);
         }
@@ -948,7 +951,16 @@ vga_bios_error:
 
     register_ioport_write(0xf0, 1, 1, ioportF0_write, NULL);
 
-    if (cirrus_vga_enabled) {
+    if (s3_vga_enabled) {
+        if (pci_enabled) {
+            pci_s3virge_vga_init(pci_bus,
+                                 phys_ram_base + vga_ram_addr,
+                                 vga_ram_addr, vga_ram_size);
+        } else {
+            isa_s3virge_vga_init(phys_ram_base + vga_ram_addr,
+                                 vga_ram_addr, vga_ram_size);
+        }
+    } else if (cirrus_vga_enabled) {
         if (pci_enabled) {
             pci_cirrus_vga_init(pci_bus,
                                 phys_ram_base + vga_ram_addr,

--- a/qemu-0.10.0/hw/pc.h
+++ b/qemu-0.10.0/hw/pc.h
@@ -149,6 +149,10 @@ void pci_cirrus_vga_init(PCIBus *bus, uint8_t *vga_ram_base,
                          ram_addr_t vga_ram_offset, int vga_ram_size);
 void isa_cirrus_vga_init(uint8_t *vga_ram_base,
                          ram_addr_t vga_ram_offset, int vga_ram_size);
+void pci_s3virge_vga_init(PCIBus *bus, uint8_t *vga_ram_base,
+                          ram_addr_t vga_ram_offset, int vga_ram_size);
+void isa_s3virge_vga_init(uint8_t *vga_ram_base,
+                          ram_addr_t vga_ram_offset, int vga_ram_size);
 
 /* ide.c */
 void isa_ide_init(int iobase, int iobase2, qemu_irq irq,

--- a/qemu-0.10.0/hw/pci.h
+++ b/qemu-0.10.0/hw/pci.h
@@ -53,6 +53,8 @@ extern target_phys_addr_t pci_mem_base;
 #define PCI_DEVICE_ID_DEC_21154          0x0026
 
 #define PCI_VENDOR_ID_CIRRUS             0x1013
+#define PCI_VENDOR_ID_S3                 0x5333
+#define PCI_DEVICE_ID_S3_VIRGE           0x8a01
 
 #define PCI_VENDOR_ID_IBM                0x1014
 #define PCI_DEVICE_ID_IBM_OPENPIC2       0xffff

--- a/qemu-0.10.0/hw/s3_virge_vga.c
+++ b/qemu-0.10.0/hw/s3_virge_vga.c
@@ -1,0 +1,65 @@
+#include "hw.h"
+#include "pc.h"
+#include "pci.h"
+#include "console.h"
+#include "vga_int.h"
+
+typedef struct PCIS3VGAState {
+    PCIDevice dev;
+    VGAState vga;
+} PCIS3VGAState;
+
+static void pci_s3vga_map(PCIDevice *d, int region_num,
+                          uint32_t addr, uint32_t size, int type)
+{
+    VGAState *s = &container_of(d, PCIS3VGAState, dev)->vga;
+    vga_map(s, addr, size, type);
+}
+
+static void pci_s3vga_write_config(PCIDevice *d, uint32_t address,
+                                   uint32_t val, int len)
+{
+    pci_default_write_config(d, address, val, len);
+}
+
+void pci_s3virge_vga_init(PCIBus *bus, uint8_t *vga_ram_base,
+                          ram_addr_t vga_ram_offset, int vga_ram_size)
+{
+    PCIS3VGAState *d;
+    VGAState *s;
+    uint8_t *pci_conf;
+
+    d = (PCIS3VGAState *)pci_register_device(bus, "S3 ViRGE VGA",
+                                             sizeof(PCIS3VGAState),
+                                             -1, NULL, pci_s3vga_write_config);
+    if (!d)
+        return;
+
+    s = &d->vga;
+    vga_common_init(s, vga_ram_base, vga_ram_offset, vga_ram_size);
+    vga_init(s);
+
+    s->ds = graphic_console_init(s->update, s->invalidate,
+                                 s->screen_dump, s->text_update, s);
+
+    s->pci_dev = &d->dev;
+    pci_conf = d->dev.config;
+    pci_config_set_vendor_id(pci_conf, PCI_VENDOR_ID_S3);
+    pci_config_set_device_id(pci_conf, PCI_DEVICE_ID_S3_VIRGE);
+    pci_config_set_class(pci_conf, PCI_CLASS_DISPLAY_VGA);
+    pci_conf[0x0e] = 0x00;
+
+    pci_register_io_region(&d->dev, 0, vga_ram_size,
+                           PCI_ADDRESS_SPACE_MEM_PREFETCH, pci_s3vga_map);
+}
+
+void isa_s3virge_vga_init(uint8_t *vga_ram_base,
+                          ram_addr_t vga_ram_offset, int vga_ram_size)
+{
+    VGAState *s = qemu_mallocz(sizeof(VGAState));
+
+    vga_common_init(s, vga_ram_base, vga_ram_offset, vga_ram_size);
+    vga_init(s);
+    s->ds = graphic_console_init(s->update, s->invalidate,
+                                 s->screen_dump, s->text_update, s);
+}

--- a/qemu-0.10.0/qemu-doc.texi
+++ b/qemu-0.10.0/qemu-doc.texi
@@ -194,7 +194,7 @@ VGA BIOS.
 QEMU uses YM3812 emulation by Tatsuyuki Satoh.
 
 QEMU uses GUS emulation(GUSEMU32 @url{http://www.deinmeister.de/gusemu/})
-by Tibor "TS" Schütz.
+by Tibor "TS" SchÃ¼tz.
 
 CS4231A is the chip used in Windows Sound System and GUSMAX products
 
@@ -523,6 +523,9 @@ Cirrus Logic GD5446 Video card. All Windows versions starting from
 Windows 95 should recognize and use this graphic card. For optimal
 performances, use 16 bit color depth in the guest and the host OS.
 (This one is the default)
+@item s3virge
+S3 ViRGE compatible adapter. Implemented using the standard VGA core
+with S3 vendor and device identifiers.  QEMU does not ship an S3 VGA BIOS, so use @code{-option-rom} to load an appropriate ROM image.
 @item std
 Standard VGA card with Bochs VBE extensions.  If your guest OS
 supports the VESA 2.0 VBE extensions (e.g. Windows XP) and if you want
@@ -2968,7 +2971,7 @@ MV88W8xx8 Ethernet controller
 @item
 MV88W8618 audio controller, WM8750 CODEC and mixer
 @item
-128�64 display with brightness control
+128×64 display with brightness control
 @item
 2 buttons, 2 navigation wheels with button function
 @end itemize

--- a/qemu-0.10.0/sysemu.h
+++ b/qemu-0.10.0/sysemu.h
@@ -81,6 +81,7 @@ extern int bios_size;
 extern int cirrus_vga_enabled;
 extern int std_vga_enabled;
 extern int vmsvga_enabled;
+extern int s3_vga_enabled;
 extern int graphic_width;
 extern int graphic_height;
 extern int graphic_depth;

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -206,6 +206,7 @@ static int rtc_date_offset = -1; /* -1 means no change */
 int cirrus_vga_enabled = 1;
 int std_vga_enabled = 0;
 int vmsvga_enabled = 0;
+int s3_vga_enabled = 0;
 #ifdef TARGET_SPARC
 int graphic_width = 1024;
 int graphic_height = 768;
@@ -3949,7 +3950,7 @@ static void help(int exitcode)
            "-sdl            enable SDL\n"
 #endif
            "-portrait       rotate graphical output 90 deg left (only PXA LCD)\n"
-           "-vga [std|cirrus|vmware|none]\n"
+           "-vga [std|cirrus|vmware|s3virge|none]\n"
            "                select video card type\n"
            "-full-screen    start in full screen\n"
 #if defined(TARGET_PPC) || defined(TARGET_SPARC)
@@ -4522,18 +4523,27 @@ static void select_vgahw (const char *p)
         std_vga_enabled = 1;
         cirrus_vga_enabled = 0;
         vmsvga_enabled = 0;
+        s3_vga_enabled = 0;
     } else if (strstart(p, "cirrus", &opts)) {
         cirrus_vga_enabled = 1;
+        std_vga_enabled = 0;
+        vmsvga_enabled = 0;
+        s3_vga_enabled = 0;
+    } else if (strstart(p, "s3virge", &opts)) {
+        s3_vga_enabled = 1;
+        cirrus_vga_enabled = 0;
         std_vga_enabled = 0;
         vmsvga_enabled = 0;
     } else if (strstart(p, "vmware", &opts)) {
         cirrus_vga_enabled = 0;
         std_vga_enabled = 0;
         vmsvga_enabled = 1;
+        s3_vga_enabled = 0;
     } else if (strstart(p, "none", &opts)) {
         cirrus_vga_enabled = 0;
         std_vga_enabled = 0;
         vmsvga_enabled = 0;
+        s3_vga_enabled = 0;
     } else {
     invalid_vga:
         fprintf(stderr, "Unknown vga type: %s\n", p);


### PR DESCRIPTION
## Summary
- load `vgabios-s3virge.bin` when S3 VGA card is selected
- document that an external S3 BIOS image is required

## Testing
- `make s3_virge_vga.o` *(fails: unknown type names in pc.h)*

------
https://chatgpt.com/codex/tasks/task_e_68508aec90d0832c82fa3f3be856e03a