### PR TITLE
Add qemu 0.10 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ docker run -it --rm qemu-0.9.1
 ```
 
 The build outputs are installed under `/usr/local` inside the container.
+
+## Kompilace QEMU 0.10
+
+Pro lokální sestavení verze 0.10 je nutné nejprve nainstalovat potřebné závislosti:
+
+```bash
+sudo apt-get install build-essential libsdl1.2-dev libasound2-dev libfdt-dev libncurses-dev zlib1g-dev
+```
+
+Následně je možné spustit kompilaci a instalaci:
+
+```bash
+cd qemu-0.10.0
+./configure --prefix=/usr/local --target-list=i386-softmmu
+make
+sudo make install
+```
+


### PR DESCRIPTION
## Summary
- update README with instructions in Czech for installing dependencies and compiling QEMU 0.10

## Testing
- `apt-get install -y build-essential libsdl1.2-dev libasound2-dev zlib1g-dev libfdt-dev libncurses-dev`
- `./configure --prefix=/usr/local --target-list=i386-softmmu`
- `make` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6850918178a0832c9fb87646daf1c74a