### PR TITLE
Fix QEMU 0.10 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,25 @@ docker run -it --rm qemu-0.9.1
 ```
 
 The build outputs are installed under `/usr/local` inside the container.
+
+## Kompilace QEMU 0.10
+
+Pro lokální sestavení verze 0.10 je nutné nejprve nainstalovat potřebné závislosti:
+
+```bash
+sudo apt-get install build-essential libsdl1.2-dev libasound2-dev libfdt-dev libncurses-dev zlib1g-dev
+```
+
+Zdrojové kódy v tomto repozitáři obsahují drobnou opravu, která umožňuje úspěšné
+zkompilování verze 0.10 i s novějšími překladači.
+
+Následně je možné spustit kompilaci a instalaci:
+
+```bash
+cd qemu-0.10.0
+./configure --prefix=/usr/local --target-list=i386-softmmu
+make
+sudo make install
+```
+
+

--- a/qemu-0.10.0/hw/s3_virge_vga.c
+++ b/qemu-0.10.0/hw/s3_virge_vga.c
@@ -12,8 +12,7 @@ typedef struct PCIS3VGAState {
 static void pci_s3vga_map(PCIDevice *d, int region_num,
                           uint32_t addr, uint32_t size, int type)
 {
-    VGAState *s = &container_of(d, PCIS3VGAState, dev)->vga;
-    vga_map(s, addr, size, type);
+    vga_map(d, region_num, addr, size, type);
 }
 
 static void pci_s3vga_write_config(PCIDevice *d, uint32_t address,

--- a/qemu-0.10.0/hw/vga.c
+++ b/qemu-0.10.0/hw/vga.c
@@ -2242,8 +2242,8 @@ void vga_dirty_log_stop(VGAState *s)
     }
 }
 
-static void vga_map(PCIDevice *pci_dev, int region_num,
-                    uint32_t addr, uint32_t size, int type)
+void vga_map(PCIDevice *pci_dev, int region_num,
+             uint32_t addr, uint32_t size, int type)
 {
     PCIVGAState *d = (PCIVGAState *)pci_dev;
     VGAState *s = &d->vga_state;

--- a/qemu-0.10.0/hw/vga_int.h
+++ b/qemu-0.10.0/hw/vga_int.h
@@ -199,6 +199,9 @@ void vga_reset(void *s);
 void vga_dirty_log_start(VGAState *s);
 void vga_dirty_log_stop(VGAState *s);
 
+void vga_map(PCIDevice *pci_dev, int region_num,
+             uint32_t addr, uint32_t size, int type);
+
 uint32_t vga_mem_readb(void *opaque, target_phys_addr_t addr);
 void vga_mem_writeb(void *opaque, target_phys_addr_t addr, uint32_t val);
 void vga_invalidate_scanlines(VGAState *s, int y1, int y2);


### PR DESCRIPTION
## Summary
- expose `vga_map` so other devices can link against it
- update S3 ViRGE driver to call `vga_map` with proper parameters
- mention build fix in README

## Testing
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_6850918178a0832c9fb87646daf1c74a